### PR TITLE
feat(dynamo-tools): optionally wait for dynamo table deletions to complete

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -90,9 +90,11 @@ RDS._rdsResponses = _rdsResponses;
 
 const _dynamoResponses = {
   deleteTable: {},
+  waitFor: {},
 };
 const _dynamoConstructor = jest.fn();
 const _deleteTable = jest.fn(async () => _dynamoResponses.deleteTable);
+const _waitFor = jest.fn(async () => _dynamoResponses.waitFor);
 
 class DynamoDB {
   constructor(params) {
@@ -101,10 +103,14 @@ class DynamoDB {
   deleteTable(params) {
     return { promise: _deleteTable.bind(this, params) };
   }
+  waitFor(state, params) {
+    return { promise: _waitFor.bind(this, state, params) };
+  }
 }
 
 DynamoDB._dynamoConstructor = _dynamoConstructor;
 DynamoDB._deleteTable = _deleteTable;
+DynamoDB._waitFor = _waitFor;
 DynamoDB._dynamoResponses = _dynamoResponses;
 
 const _aasResponses = {

--- a/src/main/DynamoTools.ts
+++ b/src/main/DynamoTools.ts
@@ -12,6 +12,7 @@ import { StackReference } from './constants';
 export interface DynamoConfig extends AwsConfig {
   tableNameA: string;
   tableNameB: string;
+  waitForTableDelete?: boolean;
 }
 
 /**
@@ -48,5 +49,9 @@ export class DynamoTools {
   public async deleteTable(reference: StackReference): Promise<void> {
     const TableName = this.getTableName(reference);
     await this.dynamo.deleteTable({ TableName }).promise();
+
+    if (this.config.waitForTableDelete) {
+      await this.dynamo.waitFor('tableNotExists', { TableName }).promise();
+    }
   }
 }

--- a/src/test/DynamoTools.test.js
+++ b/src/test/DynamoTools.test.js
@@ -21,5 +21,23 @@ describe('DynamoTools', () => {
         TableName: config.tableNameB,
       });
     });
+    it('waits for table deletion to complete when config is true', async () => {
+      config.waitForTableDelete = true;
+      await dynamoTools.deleteTable(StackReference.b);
+      expect(AWS.DynamoDB._deleteTable).toHaveBeenCalledWith({
+        TableName: config.tableNameB,
+      });
+      expect(AWS.DynamoDB._waitFor).toHaveBeenCalledWith('tableNotExists', {
+        TableName: config.tableNameB,
+      });
+    });
+    it('does not wait for table deletion to complete when config is false', async () => {
+      config.waitForTableDelete = false;
+      await dynamoTools.deleteTable(StackReference.b);
+      expect(AWS.DynamoDB._deleteTable).toHaveBeenCalledWith({
+        TableName: config.tableNameB,
+      });
+      expect(AWS.DynamoDB._waitFor).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
* Adds the ability to wait for the dynamo table deletion to complete fully.

Usecase: Calls to `deleteTable` only start the table deletion process and then returns. However, the deletion may not have actually completed and could take some time. Some other process then tries to create or describe a table with the same name. An error is reported that the table is currently in a `DELETING` state. This change optionally ensures that the table has been deleted fully before returning by checking if the config provided has a wait setting enabled.