### PR TITLE
feat: add kinesis toolset to support consumer stream management

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -327,11 +327,49 @@ CloudWatch._enableAlarmActions = _enableAlarmActions;
 CloudWatch._disableAlarmActions = _disableAlarmActions;
 CloudWatch._describeAlarms = _describeAlarms;
 
+const _kinesisResponses = {
+  registerStreamConsumer: {
+    Consumer: {
+      ConsumerName: 'con1',
+      ConsumerARN:
+        'arn:aws:kinesis:eu-central-1:123456789:stream/my-stream-dev/consumer/con1:1607511009',
+      ConsumerStatus: 'CREATING',
+      ConsumerCreationTimestamp: '2020-12-09T10:50:09+00:00',
+    },
+  },
+  deregisterStreamConsumer: {},
+};
+const _kinesisConstructor = jest.fn();
+const _registerStreamConsumer = jest.fn(
+  async () => _kinesisResponses.registerStreamConsumer
+);
+const _deregisterStreamConsumer = jest.fn(
+  async () => _kinesisResponses.deregisterStreamConsumer
+);
+
+class Kinesis {
+  constructor(params) {
+    _kinesisConstructor(params);
+  }
+  registerStreamConsumer(params) {
+    return { promise: _registerStreamConsumer.bind(this, params) };
+  }
+  deregisterStreamConsumer(params) {
+    return { promise: _deregisterStreamConsumer.bind(this, params) };
+  }
+}
+
+Kinesis._kinesisConstructor = _kinesisConstructor;
+Kinesis._registerStreamConsumer = _registerStreamConsumer;
+Kinesis._deregisterStreamConsumer = _deregisterStreamConsumer;
+Kinesis._kinesisResponses = _kinesisResponses;
+
 module.exports = {
   ApplicationAutoScaling,
   CloudWatchEvents,
   CloudWatch,
   DynamoDB,
+  Kinesis,
   Lambda,
   RDS,
   SNS,

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -220,6 +220,46 @@ const _lambdaResponses = {
       },
     ],
   },
+  createEventSourceMapping: {
+    UUID: 'e2fc5e11-79cc-47b1-bd80-fcd7a852b214',
+    StartingPosition: 'TRIM_HORIZON',
+    BatchSize: 100,
+    MaximumBatchingWindowInSeconds: 0,
+    ParallelizationFactor: 1,
+    EventSourceArn:
+      'arn:aws:kinesis:eu-central-1:123456789:stream/my-stream-dev',
+    FunctionArn: 'arn:aws:lambda:eu-central-1:123456789:function:my-fn-dev',
+    LastModified: '2020-12-09T11:26:31.934000+00:00',
+    LastProcessingResult: 'No records processed',
+    State: 'Creating',
+    StateTransitionReason: 'User action',
+    DestinationConfig: {
+      OnFailure: {},
+    },
+    MaximumRecordAgeInSeconds: -1,
+    BisectBatchOnFunctionError: false,
+    MaximumRetryAttempts: -1,
+  },
+  deleteEventSourceMapping: {
+    UUID: '091a66ea-1d4c-411c-97f0-039905401602',
+    StartingPosition: 'TRIM_HORIZON',
+    BatchSize: 100,
+    MaximumBatchingWindowInSeconds: 0,
+    ParallelizationFactor: 1,
+    EventSourceArn:
+      'arn:aws:kinesis:eu-central-1:123456789:stream/my-stream-dev',
+    FunctionArn: 'arn:aws:lambda:eu-central-1:123456789:function:my-fn-dev',
+    LastModified: '2020-12-08T17:32:00+00:00',
+    LastProcessingResult: 'OK',
+    State: 'Deleting',
+    StateTransitionReason: 'User action',
+    DestinationConfig: {
+      OnFailure: {},
+    },
+    MaximumRecordAgeInSeconds: -1,
+    BisectBatchOnFunctionError: false,
+    MaximumRetryAttempts: -1,
+  },
 };
 
 const _lambdaConstructor = jest.fn();
@@ -228,6 +268,12 @@ const _listEventSourceMappings = jest.fn(
 );
 const _updateEventSourceMapping = jest.fn(
   async () => _lambdaResponses.updateEventSourceMapping
+);
+const _createEventSourceMapping = jest.fn(
+  async () => _lambdaResponses.createEventSourceMapping
+);
+const _deleteEventSourceMapping = jest.fn(
+  async () => _lambdaResponses.deleteEventSourceMapping
 );
 
 class Lambda {
@@ -240,11 +286,19 @@ class Lambda {
   updateEventSourceMapping(params) {
     return { promise: _updateEventSourceMapping.bind(this, params) };
   }
+  createEventSourceMapping(params) {
+    return { promise: _createEventSourceMapping.bind(this, params) };
+  }
+  deleteEventSourceMapping(params) {
+    return { promise: _deleteEventSourceMapping.bind(this, params) };
+  }
 }
 
 Lambda._lambdaConstructor = _lambdaConstructor;
 Lambda._listEventSourceMappings = _listEventSourceMappings;
 Lambda._updateEventSourceMapping = _updateEventSourceMapping;
+Lambda._createEventSourceMapping = _createEventSourceMapping;
+Lambda._deleteEventSourceMapping = _deleteEventSourceMapping;
 Lambda._lambdaResponses = _lambdaResponses;
 
 const _eventsConstructor = jest.fn();

--- a/src/main/KinesisTools.ts
+++ b/src/main/KinesisTools.ts
@@ -1,0 +1,77 @@
+import { Kinesis } from 'aws-sdk';
+import { RegisterStreamConsumerOutput } from 'aws-sdk/clients/kinesis';
+
+import { AwsConfig } from './common-interfaces';
+import { StackReference } from './constants';
+
+/**
+ * Configuration options for the Aurora toolkit
+ * @export
+ * @interface KinesisConfig
+ * @extends {AwsConfig}
+ */
+export interface KinesisConfig extends AwsConfig {
+  streamArn: string;
+  consumerNameA: string;
+  consumerNameB: string;
+}
+
+/**
+ * Toolkit for Kinesis data stream operations
+ * @export
+ * @class KinesisTools
+ */
+export class KinesisTools {
+  config: KinesisConfig;
+  kinesis: Kinesis;
+
+  /**
+   * Creates an instance of KinesisTools.
+   * @param {KinesisConfig} config - Configuration options for the Kinesis toolkit
+   * @memberof KinesisTools
+   */
+  public constructor(config: KinesisConfig) {
+    this.config = config;
+    this.kinesis = new Kinesis({ region: this.config.awsRegion });
+  }
+
+  protected getConsumerName(
+    ref: StackReference
+  ): KinesisConfig['consumerNameA'] | KinesisConfig['consumerNameB'] {
+    return ref === StackReference.a
+      ? this.config.consumerNameA
+      : this.config.consumerNameB;
+  }
+
+  /**
+   * Registers a new consumer for a Kinesis data stream
+   * @param {StackReference} reference - Reference to an active stack
+   * @returns {Promise<RegisterStreamConsumerOutput>}
+   * @memberof KinesisTools
+   */
+  public async registerConsumer(
+    reference: StackReference
+  ): Promise<RegisterStreamConsumerOutput> {
+    return await this.kinesis
+      .registerStreamConsumer({
+        StreamARN: this.config.streamArn,
+        ConsumerName: this.getConsumerName(reference),
+      })
+      .promise();
+  }
+
+  /**
+   * Deregisters an existing consumer for a Kinesis data stream
+   * @param {StackReference} reference - Reference to an active stack
+   * @returns {Promise<void>}
+   * @memberof KinesisTools
+   */
+  public async deregisterConsumer(reference: StackReference): Promise<void> {
+    await this.kinesis
+      .deregisterStreamConsumer({
+        StreamARN: this.config.streamArn,
+        ConsumerName: this.getConsumerName(reference),
+      })
+      .promise();
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,3 +6,4 @@ export { SnsTools } from './SnsTools';
 export { SqsTools } from './SqsTools';
 export { LambdaTools } from './LambdaTools';
 export { CloudWatchTools } from './CloudwatchTools';
+export { KinesisTools } from './KinesisTools';

--- a/src/test/KinesisTools.test.js
+++ b/src/test/KinesisTools.test.js
@@ -1,0 +1,41 @@
+import * as AWS from 'aws-sdk';
+
+import { KinesisTools, StackReference } from '../main';
+
+const config = {
+  awsRegion: 'eu-central-1',
+  awsProfile: '555',
+  environment: 'dev',
+  namespace: 'fn',
+  tags: {},
+  streamArn: 'arn:aws:kinesis:eu-central-1:123456789:stream/my-stream-dev',
+  consumerNameA: 'con1A',
+  consumerNameB: 'con1B',
+};
+
+const kinesisTools = new KinesisTools(config);
+
+describe('KinesisTools', () => {
+  describe('registerConsumer', () => {
+    it('calls registerConsumer with expected params', async () => {
+      const consumer = await kinesisTools.registerConsumer(StackReference.a);
+
+      expect(AWS.Kinesis._registerStreamConsumer).toHaveBeenCalledTimes(1);
+      expect(AWS.Kinesis._registerStreamConsumer).toHaveBeenCalledWith({
+        ConsumerName: config.consumerNameA,
+        StreamARN: config.streamArn,
+      });
+      expect(consumer).not.toBeUndefined();
+    });
+
+    it('calls deregisterConsumer with expected params', async () => {
+      await kinesisTools.deregisterConsumer(StackReference.b);
+
+      expect(AWS.Kinesis._deregisterStreamConsumer).toHaveBeenCalledTimes(1);
+      expect(AWS.Kinesis._deregisterStreamConsumer).toHaveBeenCalledWith({
+        ConsumerName: config.consumerNameB,
+        StreamARN: config.streamArn,
+      });
+    });
+  });
+});

--- a/src/test/KinesisTools.test.js
+++ b/src/test/KinesisTools.test.js
@@ -27,7 +27,8 @@ describe('KinesisTools', () => {
       });
       expect(consumer).not.toBeUndefined();
     });
-
+  });
+  describe('registerConsumer', () => {
     it('calls deregisterConsumer with expected params', async () => {
       await kinesisTools.deregisterConsumer(StackReference.b);
 

--- a/src/test/LambdaTools.test.ts
+++ b/src/test/LambdaTools.test.ts
@@ -144,4 +144,80 @@ describe('LambdaTools', () => {
       });
     });
   });
+  describe('listEventSourceMappings', () => {
+    it('calls listEventSourceMappings with expected params', async () => {
+      const mappings = await lambdaTools.listEventSourceMappings(
+        StackReference.b
+      );
+      expect(AWS.Lambda._listEventSourceMappings).toHaveBeenCalledWith({
+        FunctionName: 'arn:aws:lambda:eu-central-1:555:function:fn-b-dev',
+      });
+      expect(mappings).not.toBeUndefined();
+    });
+    it('calls updateEventSourceMapping with expected params and variant', async () => {
+      const lambda = new LambdaTools({
+        awsRegion: 'eu-central-1',
+        awsProfile: '555',
+        environment: 'dev',
+        namespace: 'fn',
+        tags: {},
+        lambdaNameA: 'fn-a-dev',
+        lambdaNameB: 'fn-b-dev',
+        alias: 'live',
+      });
+      const mappings = await lambda.listEventSourceMappings(StackReference.b);
+      expect(AWS.Lambda._listEventSourceMappings).toHaveBeenCalledWith({
+        FunctionName: 'arn:aws:lambda:eu-central-1:555:function:fn-b-dev:live',
+      });
+      expect(mappings).not.toBeUndefined();
+    });
+  });
+  describe('createEventSourceMapping', () => {
+    it('calls createEventSourceMapping with expected params', async () => {
+      const mapping = await lambdaTools.createEventSourceMapping(
+        StackReference.b,
+        'some-arn',
+        {
+          StartingPosition: 'TRIM_HORIZON',
+        }
+      );
+      expect(AWS.Lambda._createEventSourceMapping).toHaveBeenCalledWith({
+        FunctionName: 'arn:aws:lambda:eu-central-1:555:function:fn-b-dev',
+        EventSourceArn: 'some-arn',
+        StartingPosition: 'TRIM_HORIZON',
+      });
+      expect(mapping).not.toBeUndefined();
+    });
+    it('calls updateEventSourceMapping with expected params and variant', async () => {
+      const lambda = new LambdaTools({
+        awsRegion: 'eu-central-1',
+        awsProfile: '555',
+        environment: 'dev',
+        namespace: 'fn',
+        tags: {},
+        lambdaNameA: 'fn-a-dev',
+        lambdaNameB: 'fn-b-dev',
+        alias: 'live',
+      });
+      const mapping = await lambda.createEventSourceMapping(
+        StackReference.b,
+        'some-arn'
+      );
+      expect(AWS.Lambda._createEventSourceMapping).toHaveBeenCalledWith({
+        FunctionName: 'arn:aws:lambda:eu-central-1:555:function:fn-b-dev:live',
+        EventSourceArn: 'some-arn',
+      });
+      expect(mapping).not.toBeUndefined();
+    });
+  });
+  describe('deleteEventMapping', () => {
+    it('calls deleteEventMapping with expected params', async () => {
+      const UUID = '091a66ea-1d4c-411c-97f0-039905401602';
+
+      await lambdaTools.deleteEventMapping(UUID);
+      expect(AWS.Lambda._deleteEventSourceMapping).toHaveBeenCalledWith({
+        UUID,
+      });
+    });
+  });
 });


### PR DESCRIPTION
* Adds a Kinesis toolset - initially to manage consumer streams (register and deregister consumers apis)
* Adds new helper methods to the Lambda toolset to make working with event source mappings easier - (create, list and delete mappings apis)